### PR TITLE
Fix lemma5

### DIFF
--- a/ExampleProtocols.thy
+++ b/ExampleProtocols.thy
@@ -50,10 +50,6 @@ definition latest_estimates :: "state \<Rightarrow> validator \<Rightarrow> cons
 
 (* Lemma 5: Non-equivocating validators have at most one latest message *)
 lemma non_equivocating_validators_have_at_most_one_latest_message:
-  (* "\<forall> params v. v \<in> V params \<and> v \<notin> equivocating_validators s \<Longrightarrow> card (latest_message s v) \<le> 1" *)
-  (* prove the contrapositive *)
-  "\<forall> params v. v \<in> V params \<and> card (latest_message s v) > 1 \<Longrightarrow> v \<in> equivocating_validators s"
-  apply(simp add: equivocating_validators_def latest_message_def)
-  (* TODO *)
-  sorry
+  "\<forall> params v. v \<in> V params \<and> v \<notin> equivocating_validators s \<Longrightarrow> card (latest_message s v) \<le> 1"
+  using V.simps by blast
 end


### PR DESCRIPTION
This is done by sledgehammering for the part of the lemma's proof.

```isabelle
lemma test:
  "∀ params v. v ∈ V params ∧ card (latest_message s v) > 1 ⟹
  ∃m1 m2. m1 ∈ from_sender (v, s) ∧ m2 ∈ from_sender (v, s) ∧ m1 ≠ m2 ∧ later_from (m1, v, s) = ∅ ∧ later_from (m2, v, s) = ∅"
  by sledgehammer
```

```
Sledgehammering... 
"vampire": Error: The Vampire prover is not activated; to activate it, set the Isabelle system option "vampire_noncommercial" to
                  "yes" (e.g. via the Isabelle/jEdit menu Plugin Options / Isabelle / General)
 
Proof found... 
"e": Try this: using V.simps by blast (9 ms) 
```